### PR TITLE
Support wiki links with spaces

### DIFF
--- a/packages/remark-wiki-link/src/lib/fromMarkdown.ts
+++ b/packages/remark-wiki-link/src/lib/fromMarkdown.ts
@@ -72,7 +72,7 @@ function fromMarkdown(opts: FromMarkdownOptions = {}) {
     const pagePermalinks = pageResolver(target, isEmbed, prefix);
 
     // eslint-disable-next-line no-useless-escape
-    const pathWithOptionalHeadingPattern = /([a-z0-9\.\/_-]*)(#.*)?/;
+    const pathWithOptionalHeadingPattern = /([a-z0-9\.\/_\s-]*)(#.*)?/;
     let targetHeading = "";
 
     const matchingPermalink = permalinks.find((e) => {

--- a/packages/remark-wiki-link/test/remarkWikiLink.spec.ts
+++ b/packages/remark-wiki-link/test/remarkWikiLink.spec.ts
@@ -257,6 +257,29 @@ describe("remark-wiki-link", () => {
       });
     });
 
+    test("Image embeds with obsidian default format", () => {
+      const processor = unified()
+        .use(markdown)
+        .use(wikiLinkPlugin, {
+          pathFormat: "obsidian-short",
+          permalinks: ["/assets/pasted image 20230509092216.png"],
+        });
+
+      let ast = processor.parse("![[pasted image 20230509092216.png]]");
+      ast = processor.runSync(ast);
+
+      expect(select("wikiLink", ast)).not.toEqual(null);
+
+      visit(ast, "wikiLink", (node: Node) => {
+        console.log(node.data)
+        expect(node.data?.exists).toEqual(true);
+        expect(node.data?.permalink).toEqual("/assets/pasted image 20230509092216.png");
+        expect(node.data?.alias).toEqual(null);
+        expect(node.data?.hName).toEqual("img");
+        expect((node.data?.hProperties as any).className).toEqual("internal");
+      });
+    });
+
     test("parses an image embed of unsupported file format", () => {
       const processor = unified().use(markdown).use(wikiLinkPlugin);
 


### PR DESCRIPTION
Added support for wiki links like the ones created when an image is pasted in obsidian:

Example:
```
![[Pasted image 20230425114940.png]]
```

Previously, this was reduced to "Pasted".


Note for reviewers: I haven't tested this change thoroughly, is there a reason why this might be problematic?