### PR TITLE
Bump of the remark-wiki-link package from 1.1.0 to 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@portaljs/core": "^1.0.7",
         "@portaljs/remark-callouts": "^1.0.5",
         "@portaljs/remark-embed": "^1.0.4",
-        "@portaljs/remark-wiki-link": "^1.1.0",
+        "@portaljs/remark-wiki-link": "^1.1.2",
         "@silvenon/remark-smartypants": "^2.0.0",
         "@tailwindcss/typography": "^0.5.9",
         "@types/node": "18.14.2",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@portaljs/remark-wiki-link": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@portaljs/remark-wiki-link/-/remark-wiki-link-1.1.0.tgz",
-      "integrity": "sha512-ICLOpIMGjNbY+Ow3TuLhgp0Dhtbe+z0SXjGEyTnLS1kxVWunjIB3Jv853bew+HSOMPP1ejqzGGNzuZl8AxuchA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@portaljs/remark-wiki-link/-/remark-wiki-link-1.1.2.tgz",
+      "integrity": "sha512-r/smysr9pI/b7RUaTZ+b7iJpxI6XPJNekNB7LN4CLkd9DSFs4jIVUunfhyUhiL91911cB67scNTb1XnEesYlTA==",
       "dependencies": {
         "mdast-util-to-markdown": "^1.5.0",
         "mdast-util-wiki-link": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@portaljs/core": "^1.0.7",
     "@portaljs/remark-callouts": "^1.0.5",
     "@portaljs/remark-embed": "^1.0.4",
-    "@portaljs/remark-wiki-link": "^1.1.0",
+    "@portaljs/remark-wiki-link": "^1.1.2",
     "@silvenon/remark-smartypants": "^2.0.0",
     "@tailwindcss/typography": "^0.5.9",
     "@types/node": "18.14.2",


### PR DESCRIPTION
fix #565 

## Changes

Bump of the remark-wiki-link package from 1.1.0 to 1.1.2.