### PR TITLE
[][m]: Add image size adjustment

### DIFF
--- a/lib/replaceMdImages.ts
+++ b/lib/replaceMdImages.ts
@@ -1,0 +1,44 @@
+export function replaceMdImages(content: string): string {
+    let newContent = content;
+
+    newContent = replaceNormalImages(newContent);
+    newContent = replaceObsidianImages(newContent);
+
+    return newContent;
+}
+
+const normalImgRegex = /!\[(.*?)\]\((.*?)\)/g;
+function replaceNormalImages(content: string): string {
+    const newContent = content.replace(normalImgRegex, (_, altText: string, imageUrl: string) => {
+        const [alt, size] = altText.split('|');
+
+        if (!size) return `<img src="${imageUrl}" alt="${alt}"/>`;
+
+        const { width, height } = getImageSize(size);
+        return `<img src="${imageUrl}" alt="${alt}" width="${width}" height="${height}"/>`;
+    });
+
+    return newContent;
+}
+
+const obsidianImgRegex = /!\[\[([^\]]*?)\]\]/g;
+function replaceObsidianImages(content: string): string {
+    const newContent = content.replace(obsidianImgRegex, (match, imageUrl) => {
+        const [url, size] = imageUrl.split('|');
+
+        if (!size) return `<img src="${url}" alt="image"/>`;
+
+        const { width, height } = getImageSize(size);
+        return `<img src="${url}" alt="image" width="${width}" height="${height}"/>`;
+    });
+
+    return newContent;
+}
+
+function getImageSize(size: string): { width: string; height: string } {
+    let [width, height] = size.split('x');
+
+    if (!height) height = width;
+
+    return { width, height };
+}

--- a/pages/[[...slug]].tsx
+++ b/pages/[[...slug]].tsx
@@ -9,6 +9,7 @@ import computeFields from "@/lib/computeFields";
 import parse from "@/lib/markdown";
 import siteConfig from "@/config/siteConfig";
 import type { CustomAppProps } from "./_app";
+import { replaceMdImages } from "@/lib/replaceMdImages";
 
 interface SlugPageProps extends CustomAppProps {
     source: any;
@@ -62,7 +63,8 @@ export const getStaticProps: GetStaticProps = async ({
     const frontMatter = dbFile!.metadata ?? {};
 
     const source = fs.readFileSync(filePath, { encoding: "utf-8" });
-    const { mdxSource } = await parse(source, "mdx", {});
+    const newSource = replaceMdImages(source);
+    const { mdxSource } = await parse(newSource, "mdx", {});
 
     // TODO temporary replacement for contentlayer's computedFields
     const frontMatterWithComputedFields = await computeFields({


### PR DESCRIPTION
For https://github.com/datopian/flowershow/issues/592

I am replacing embeded images `![[image.png|100]]` with HTML <img> tags. 
Example:

1- 
```
![image.png|100x100](src)  // Initial

<img src="image" width="100" height="100"/> // result
```
2- 
```
![alt](src) --> <img src="src"/>
![alt|200](src) --> <img src="src" width="200" height="200"/>
![alt|200x300](src)  --> <img src="src" width="200" height="300"/>
```
