### PR TITLE
Fix YAML properties with hyphens cause Build error

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -18,6 +18,19 @@ import { serialize } from "next-mdx-remote/serialize";
 
 import siteConfig from "@/config/siteConfig";
 
+function sanitizeKeys(obj: Record<string, any>): Record<string, any> {
+  const sanitizedObj: Record<string, any> = {};
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const sanitizedKey = key.replace(/[^a-zA-Z0-9_$]/g, '_'); // Removes characters that are not alphabets, numbers, underscore, or dollar sign
+      sanitizedObj[sanitizedKey] = obj[key];
+    }
+  }
+
+  return sanitizedObj;
+}
+
 /**
  * Parse a markdown or MDX file to an MDX source form + front matter data
  *
@@ -96,6 +109,7 @@ const parse = async function (source, format, scope) {
       scope: { ...scope, ...data },
     }
   );
+  mdxSource.scope = sanitizeKeys(mdxSource.scope);
 
   return {
     mdxSource: mdxSource,


### PR DESCRIPTION
For issue #636:

- After debugging, I discovered that `MDX-Remote` is the cause of this failure.
- It seems to use YAML properties within a `new function(arg1, arg2)` format, where each argument corresponds to a YAML property. This requires the properties to be in a format that's a valid variable name (i.e., no spaces or strange characters).
- `MDX-Remote` replaces variables in the content body with these YAML properties, like so:
```
---
my_name: "Mohamed"
---
My name is {my_name} // the output will be My name is Mohamed
```
- This pull request replaces all hyphens/other characters in the YAML properties with underscores.
- However, it doesn't handle cases where a user employs the YAML property as a variable value. Since this PR doesn't modify the content of the file itself (i.e., it won't change hyphens in the body `{my-name}` to underscores `{my_name}`), this scenario remains unaddressed.